### PR TITLE
feat: Add `reuse` for multiple dialog

### DIFF
--- a/viur/scriptor/_utils.py
+++ b/viur/scriptor/_utils.py
@@ -34,6 +34,9 @@ if is_pyodide_context():
         while manager.resultValue is None:
             await manager.sleep(250)
         res = manager.resultValue
+        if res == "__exit__":
+            import sys
+            sys.exit(0)
         manager.reset()
         manager.resultValue = None
         return res

--- a/viur/scriptor/dialog.py
+++ b/viur/scriptor/dialog.py
@@ -656,7 +656,7 @@ class Dialog:
             }
 
 
-             if not reuse:
+            if not reuse:
                 js.self.postMessage(**msg)
             res = await _wait_for_result()
             if isinstance(res,str):

--- a/viur/scriptor/dialog.py
+++ b/viur/scriptor/dialog.py
@@ -643,21 +643,22 @@ class Dialog:
 
     if is_pyodide_context():
         @staticmethod
-        async def multiple(title: str, components: list):
+        async def multiple(title: str, components: list, reuse: bool = False):
             """
             :param title: the header of the component
             :param components: list of components
+            :param reuse: If True, the components are not sent to the JS.
             """
             msg = {
                 "type": "multiple-dialog",
                 "title": title,
                 "components": json.dumps(components)
             }
-            js.self.postMessage(**msg)
-            rest = await _wait_for_result()
-            return json.loads(rest)
+            if not reuse:
+                js.self.postMessage(**msg)
+            return json.loads(await _wait_for_result())
 
     else:
         @staticmethod
-        async def multiple(title: str, components: list):
+        async def multiple(title: str, components: list, reuse: bool = False):
             return components


### PR DESCRIPTION
This PR is for something like this

```python
reuse = False
    while True:
          results = await Dialog.multiple("foo", steps, reuse = reuse)
          await download_data(results)
          reuse = True

```
So you not must send the components to the js over and over again.