### PR TITLE
feat: Provide `export_to_json()`-function in exporter

### DIFF
--- a/viur/scriptor/export_import.py
+++ b/viur/scriptor/export_import.py
@@ -539,6 +539,10 @@ def export_to_table(data, structure, filename="export.csv"):
     return csv_file
 
 
+def export_to_json(data, structure, filename="export.json"):
+    return File(json.dumps(_format_for_table(data, structure), indent=4, sort_keys=True).encode(), filename)
+
+
 def generate_key_replacement_mapping(table_header_keys, replacekeys):
     replace_bone_name_mapping = {}
     for table_header_key in table_header_keys:

--- a/viur/scriptor/file.py
+++ b/viur/scriptor/file.py
@@ -71,7 +71,7 @@ class File:
         if file_suffix == "xlsx":
             data = list_to_excel(normalized_table)
         elif file_suffix == "csv":
-            data = list_to_csv(normalized_table, delimiter=csv_delimiter).encode('UTF-8')
+            data = list_to_csv(normalized_table, delimiter=csv_delimiter).encode()
         else:
             raise ValueError("Only .csv and .xlsx are supported file extensions.")
         return File(data=data, filename=filename)


### PR DESCRIPTION
This will export a two-dimensional representation of the exported data to json, likewise a CSV-table, but more useful for machine-processable data.